### PR TITLE
Added prometheus to several services

### DIFF
--- a/ansible/docker/README.md
+++ b/ansible/docker/README.md
@@ -19,3 +19,51 @@ https://hub.docker.com/r/joplin/server/tags
 ### Uptime Kuma
 
 https://hub.docker.com/r/louislam/uptime-kuma/tags
+
+## Prometheus Metrics - Network Architecture
+
+Services expose metrics endpoints via an nginx sidecar which is connected to both the prometheus network and the application network, and exposes just the metrics endpoint.
+This ensures services remain isolated on their own networks, and that prometheus has access to only the metrics endpoints, without requiring firewall setup that I don't understand.
+
+Example:
+
+```yaml
+services:
+  app:
+    networks:
+      - internal
+
+  prom_nginx:
+    image: nginx:alpine
+    networks:
+      - internal
+      - prom_bridge
+    restart: always
+    configs:
+      - source: prom_nginx_config
+        target: /etc/nginx/nginx.conf
+
+configs:
+  prom_nginx_config:
+    content: |
+      worker_processes 1;
+      events {
+        worker_connections 512;
+      }
+      http {
+        server {
+          listen 80;
+          location /metrics {
+            proxy_pass http://app:9000/metrics;
+          }
+          location / {
+            return 403;
+          }
+        }
+      }
+
+networks:
+  internal:
+  prom_bridge:
+    external: true
+```

--- a/ansible/docker/ente/compose.yml
+++ b/ansible/docker/ente/compose.yml
@@ -94,5 +94,38 @@ services:
       - internal
     restart: no
 
+  prom_nginx:
+    image: nginx:alpine
+    hostname: ente_prom_nginx
+    container_name: ente_prom_nginx
+    networks:
+      - internal
+      - prom_bridge
+    restart: always
+    configs:
+      - source: prom_nginx_config
+        target: /etc/nginx/nginx.conf
+
+configs:
+  prom_nginx_config:
+    content: |
+      worker_processes 1;
+      events {
+        worker_connections 512;
+      }
+      http {
+        server {
+          listen 80;
+          location /metrics {
+            proxy_pass http://ente_museum:2112/metrics;
+          }
+          location / {
+            return 403;
+          }
+        }
+      }
+
 networks:
   internal:
+  prom_bridge:
+    external: true

--- a/ansible/docker/grafana/compose.yml
+++ b/ansible/docker/grafana/compose.yml
@@ -42,6 +42,7 @@ services:
       - /docker/volumes/grafana/prometheus_data:/prometheus
     networks:
       - grafana_bridge
+      - prom_bridge
     restart: always
 
   node-exporter:
@@ -63,4 +64,7 @@ services:
 
 networks:
   grafana_bridge:
+    driver: bridge
+  prom_bridge:
+    name: prom_bridge
     driver: bridge

--- a/ansible/docker/grafana/prometheus.yml
+++ b/ansible/docker/grafana/prometheus.yml
@@ -11,3 +11,9 @@ scrape_configs:
   - job_name: "fail2ban_exporter"
     static_configs:
       - targets: ["fail2ban_exporter:9100"]
+  - job_name: "ente"
+    static_configs:
+      - targets: ["ente_prom_nginx:80"]
+  - job_name: "overleaf"
+    static_configs:
+      - targets: ["overleaf_prom_nginx:80"]

--- a/ansible/docker/grafana/prometheus.yml
+++ b/ansible/docker/grafana/prometheus.yml
@@ -17,3 +17,6 @@ scrape_configs:
   - job_name: "overleaf"
     static_configs:
       - targets: ["overleaf_prom_nginx:80"]
+  - job_name: "uptimekuma"
+    static_configs:
+      - targets: ["uptimekuma_prom_nginx:80"]

--- a/ansible/docker/overleaf/compose.yml
+++ b/ansible/docker/overleaf/compose.yml
@@ -32,6 +32,8 @@ services:
       # OVERLEAF_TEMPLATES_USER_ID: "578773160210479700917ee5"
       # OVERLEAF_NEW_PROJECT_TEMPLATE_LINKS: '[ {"name":"All Templates","url":"/templates/all"}]'
       # OVERLEAF_PROXY_LEARN: "true"
+    networks:
+      - overleaf_default
 
   mongo:
     container_name: overleaf_mongo
@@ -53,6 +55,8 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
+    networks:
+      - overleaf_default
 
   redis:
     container_name: overleaf_redis
@@ -61,3 +65,41 @@ services:
     image: redis:6.2
     volumes:
       - /docker/volumes/overleaf/redis_data:/data
+    networks:
+      - overleaf_default
+
+  prom_nginx:
+    image: nginx:alpine
+    hostname: overleaf_prom_nginx
+    container_name: overleaf_prom_nginx
+    networks:
+      - overleaf_default
+      - prom_bridge
+    restart: always
+    configs:
+      - source: prom_nginx_config
+        target: /etc/nginx/nginx.conf
+
+configs:
+  prom_nginx_config:
+    content: |
+      worker_processes 1;
+      events {
+        worker_connections 512;
+      }
+      http {
+        server {
+          listen 80;
+          location /metrics {
+            proxy_pass http://overleaf_sharelatex:3000/metrics;
+          }
+          location / {
+            return 403;
+          }
+        }
+      }
+
+networks:
+  overleaf_default:
+  prom_bridge:
+    external: true

--- a/ansible/docker/uptime-kuma/compose.yml
+++ b/ansible/docker/uptime-kuma/compose.yml
@@ -2,8 +2,49 @@ services:
   uptime-kuma:
     image: louislam/uptime-kuma:1.23.16-debian
     container_name: uptime-kuma
+    hostname: uptimekuma
     restart: always
     ports:
       - "127.0.0.1:8001:3001"
     volumes:
       - /docker/volumes/uptime-kuma:/app/data
+    networks:
+      - uptime-kuma_default
+
+  prom_nginx:
+    image: nginx:alpine
+    hostname: uptimekuma_prom_nginx
+    container_name: uptimekuma_prom_nginx
+    networks:
+      - uptime-kuma_default
+      - prom_bridge
+    restart: always
+    configs:
+      - source: prom_nginx_config
+        target: /etc/nginx/nginx.conf
+
+configs:
+  # UPTIME_KUMA_API_KEY := `echo -n ":API_KEY" | base64
+  prom_nginx_config:
+    content: |
+      worker_processes 1;
+      events {
+        worker_connections 512;
+      }
+      http {
+        server {
+          listen 80;
+          location /metrics {
+            proxy_pass http://uptimekuma:3001/metrics;
+            proxy_set_header Authorization "Basic ${UPTIME_KUMA_API_KEY}";
+          }
+          location / {
+            return 403;
+          }
+        }
+      }
+
+networks:
+  uptime-kuma_default:
+  prom_bridge:
+    external: true

--- a/ansible/setup-server.yml
+++ b/ansible/setup-server.yml
@@ -64,15 +64,15 @@
     - import_tasks: tasks/utils.yml
     - import_tasks: tasks/install-standard-apps.yml
     - import_tasks: tasks/prepare-docker.yml
+    - import_tasks: tasks/docker-grafana.yml
+      tags:
+        - docker
+        - grafana
     - import_tasks: tasks/docker-helloworld.yml
     - import_tasks: tasks/docker-uptime-kuma.yml
       tags:
         - docker
         - uptimekuma
-    - import_tasks: tasks/docker-grafana.yml
-      tags:
-        - docker
-        - grafana
     - import_tasks: tasks/docker-ente.yml
       tags:
         - docker


### PR DESCRIPTION
Added prometheus endpoints and collection to ente, overleaf, and uptime-kuma. Nextcloud would require an exporter, and nothing appears to be available for joplin.

The network architecture is described in the README.