### PR TITLE
Auto-install overleaf packages from list

### DIFF
--- a/ansible/docker/overleaf/compose.yml
+++ b/ansible/docker/overleaf/compose.yml
@@ -13,6 +13,9 @@ services:
     stop_grace_period: 60s
     volumes:
       - /docker/volumes/overleaf/sharelatex_data:/var/lib/overleaf
+      - ./package-list:/package-list:ro
+      - ./sharelatex-init.sh:/sharelatex-init.sh:ro
+    entrypoint: sh /sharelatex-init.sh
     environment:
       OVERLEAF_APP_NAME: Overleaf Community Edition
       OVERLEAF_MONGO_URL: mongodb://mongo/sharelatex

--- a/ansible/docker/overleaf/package-list
+++ b/ansible/docker/overleaf/package-list
@@ -1,0 +1,3 @@
+enumitem
+lipsum
+collection-fontsrecommended

--- a/ansible/docker/overleaf/sharelatex-init.sh
+++ b/ansible/docker/overleaf/sharelatex-init.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+set -u
+
+echo "**CONTAINER INIT**"
+
+while read package; do
+    echo "Installing $package"
+    tlmgr install "$package" || echo "Failed to install $package" >&2
+done < /package-list
+echo "Done"
+
+# Continue with the container's normal execution
+echo "**CONTAINER START**"
+/sbin/my_init
+echo "Exit"


### PR DESCRIPTION
The overleaf image includes a minimal set of latex packages by default. They advise you install the required packages and save that docker image, but that process would need to be repeated when upgrading.

Instead, this entrypoint automatically installs the required packages on every container start. This is not efficient for a real deployment, or for a large number of packages, but is a simple and effective solution for small deployments such as this.

Fixes #7.